### PR TITLE
feat: 5 Entity 추가 및 Service, Repository 기능 추가

### DIFF
--- a/src/main/java/com/culturelife/TicketingPlatform/Entity/Post.java
+++ b/src/main/java/com/culturelife/TicketingPlatform/Entity/Post.java
@@ -24,6 +24,8 @@ public class Post {
     @Column(length = 4000, nullable = false)
     private String postContents;
 
+    private Long viewCount = 0L;
+
     @JsonBackReference
     @ManyToOne(fetch=FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/com/culturelife/TicketingPlatform/Repository/PostRepository.java
+++ b/src/main/java/com/culturelife/TicketingPlatform/Repository/PostRepository.java
@@ -36,6 +36,14 @@ public class PostRepository {
                 .getResultList();
     }
 
+    public Long updateViewCount(Long id) {
+        em.createQuery("update Post p set p.viewCount = p.viewCount + 1 where p.id = :id")
+                .setParameter("id", id)
+                .executeUpdate();
+
+        return id;
+    }
+
     public Long counts() {
         Long count = em.createQuery("select COUNT(p) from Post p", Long.class)
                 .getSingleResult();

--- a/src/main/java/com/culturelife/TicketingPlatform/Service/PerformanceService.java
+++ b/src/main/java/com/culturelife/TicketingPlatform/Service/PerformanceService.java
@@ -55,7 +55,7 @@ public class PerformanceService {
         return performanceRepository.readAll();
     }
 
-    public List<Performance> readQuestionByPerformanceName(String performanceName) {
+    public List<Performance> readPerformanceByName(String performanceName) {
         return performanceRepository.readByPerformanceName(performanceName);
     }
 

--- a/src/main/java/com/culturelife/TicketingPlatform/Service/PostService.java
+++ b/src/main/java/com/culturelife/TicketingPlatform/Service/PostService.java
@@ -76,6 +76,8 @@ public class PostService {
     }
 
     public Post readPostById(Long id) {
+        System.out.println("update 테스트 시작");
+        postRepository.updateViewCount(id);
         return postRepository.readById(id);
     }
 

--- a/src/test/java/com/culturelife/TicketingPlatform/TicketingPlatformApplicationTests.java
+++ b/src/test/java/com/culturelife/TicketingPlatform/TicketingPlatformApplicationTests.java
@@ -2,10 +2,13 @@ package com.culturelife.TicketingPlatform;
 
 import com.culturelife.TicketingPlatform.Entity.*;
 import com.culturelife.TicketingPlatform.Service.*;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
+import org.springframework.test.annotation.Rollback;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -24,7 +27,8 @@ class TicketingPlatformApplicationTests {
 	private PostService postService;
 	@Autowired
 	private CommentService commentService;
-
+	@Autowired
+	private EntityManager em;
 
 	@Test
 	void contextLoads() {
@@ -34,10 +38,10 @@ class TicketingPlatformApplicationTests {
 	void testJpa() {
 		testMember();
 		testPost();
-		testComment();
-
-		testPerformance();
-		testSeat();
+//		testComment();
+//
+//		testPerformance();
+//		testSeat();
 
 //		System.out.println("allPerformanceList 시작");
 //		List<Performance> allPerformanceList = performanceService.readAllPerformance();
@@ -68,6 +72,7 @@ class TicketingPlatformApplicationTests {
 		}
 	}
 
+
 	private void testPost() {
 
 		System.out.println("Post 테스트 시작");
@@ -78,6 +83,9 @@ class TicketingPlatformApplicationTests {
 			post.setPostContents("내용 테스트 " + i);
 			postService.createPost("knu",post);
 		}
+
+		Post post = postService.readPostById(1L);
+		System.out.println(post.getViewCount());
 	}
 
 


### PR DESCRIPTION
1) 조회수 Entity(viewCount) 추가
2) PostService에서 readPostById(id)함수 호출하면 viewCount +1 되도록 기능 추가
3) PostRepository에서 updateViewCount() 함수에서 update 쿼리로 viewCount 변경하는 기능 추가